### PR TITLE
feat: add WithVars options

### DIFF
--- a/env.go
+++ b/env.go
@@ -109,6 +109,12 @@ func WithPrefix(prefix string) Option {
 	return func(l *loader) { l.prefix = prefix }
 }
 
+// WithVars allows to save the parsed environment into a slice of [Var]. This
+// can be handy for creating a custom usage message.
+func WithVars(vars *[]Var) Option {
+	return func(l *loader) { l.vars = vars }
+}
+
 // WithSliceSeparator configures [Load]/[LoadFrom] to use the provided separator
 // when parsing slice values. The default one is space.
 func WithSliceSeparator(sep string) Option {
@@ -136,6 +142,7 @@ type loader struct {
 	prefix      string
 	sliceSep    string
 	strictMode  bool
+	vars        *[]Var
 	usageOutput io.Writer
 }
 
@@ -166,6 +173,8 @@ func (l *loader) loadVars(dst any) (err error) {
 	if err != nil {
 		return err
 	}
+
+	*l.vars = vars
 
 	defer func() {
 		if err != nil && l.usageOutput != nil {

--- a/env_test.go
+++ b/env_test.go
@@ -187,6 +187,18 @@ func TestLoadFrom(t *testing.T) {
 		assert.Equal[E](t, called, true)
 	})
 
+	t.Run("with vars", func(t *testing.T) {
+		vars := []env.Var{}
+
+		var cfg struct {
+			Port int `env:"PORT"`
+		}
+		err := env.LoadFrom(env.Map{}, &cfg, env.WithVars(&vars))
+		assert.NoErr[F](t, err)
+		assert.Equal[E](t, len(vars), 1)
+		assert.Equal[E](t, vars[0].Name, "PORT")
+	})
+
 	t.Run("all supported types", func(t *testing.T) {
 		m := env.Map{
 			"INT": "-1", "INTS": "-1 0",


### PR DESCRIPTION
This allows to create custom usage messages. Or something like this:

```go
package main

import (
    "flag"
    "log"
    "os"

    "github.com/junk1tm/env"
)

func main() {
    cfg := struct {
        Host string `env:"HOST" default:"localhost" desc:"The host"`
        Port int    `env:"PORT" desc:"The port"`
    }{}
    vars := []env.Var{}

    err := env.LoadFrom(env.Map{}, &cfg, env.WithUsageOnError(os.Stderr), env.WithVars(&vars))
    if err != nil {
        log.Fatal(err)
    }

    flag.Usage = func() {
        env.Usage(os.Stderr, vars)
    }

    flag.Parse()
}
```